### PR TITLE
fix rts values contraints

### DIFF
--- a/oic.r.airqualitycollection.json
+++ b/oic.r.airqualitycollection.json
@@ -22,19 +22,23 @@
           },
           "rts": {
             "type": "array",
-            "minItems": 1,
-            "maxItems": 2,
             "uniqueItems": true,
-            "items": {
-              "oneOf": [
-                {
+            "oneOf": [
+              {
+                "minItems": 2,
+                "maxItems": 2,
+                "items": {
                   "enum": ["oic.r.airquality","oic.r.value.conditional"]
-                },
-                {
+                }
+              },
+              {
+                "minItems": 1,
+                "maxItems": 1,
+                "items": {
                   "enum": ["oic.r.airquality"]
                 }
-              ]
-            }
+              }
+            ]
           }
         }
       ]


### PR DESCRIPTION
This fix disallow to have only "oic.r.value.conditional"