### PR TITLE
Corrections for BZ1870-NativeOCFResourceTypesForOneM2MEquivalency

### DIFF
--- a/batterymaterial.raml
+++ b/batterymaterial.raml
@@ -34,7 +34,7 @@ traits:
             schema: BatteryMaterial
             example: |
                 {
-                    "rt": "oic.r.batterymaterial",
+                    "rt": ["oic.r.batterymaterial"],
                     "id":     "unique_example_id",
                     "material": "Alkaline"
                 }

--- a/liquidlevel.raml
+++ b/liquidlevel.raml
@@ -35,7 +35,7 @@ traits:
             schema: LiquidLevel
             example: |
               {
-                "rt":     ["oic.r.liquidlevel"],
+                "rt":     ["oic.r.liquid.level"],
                 "id":     "unique_example_id",
                 "currentlevel": 60,
                 "desiredlevel": 80

--- a/oic.r.grinder.json
+++ b/oic.r.grinder.json
@@ -24,7 +24,7 @@
   "type": "object",
   "allOf": [
     {"$ref": "oic.baseResource.json#/definitions/oic.r.baseresource"},
-    {"$ref": "#/definitions/oic.r.grinding"}
+    {"$ref": "#/definitions/oic.r.grinder"}
   ],
   "required": ["coarseness"]
 }

--- a/oic.r.vehicle.connector.json
+++ b/oic.r.vehicle.connector.json
@@ -12,7 +12,7 @@
           "description": "The connection state.",
           "readOnly": true
         },
-        "ratedchargingapacity" : {
+        "ratedchargingcapacity" : {
           "type": "number",
           "description": "The rated charging capacity in Amps (A).",
           "readOnly": true


### PR DESCRIPTION
Minor corrections for changes in c15a3df1fea743f07515e344c29e5232f4731683:
- batterymaterial.raml: made "rt" an array in example
- liquidlevel.raml: added missing dot in "rt" value in example
- oic.r.grinder.json: corrected the path to a local reference
- oic.r..vehicle.connector: corrected a typo in property name