### PR TITLE
Corrections to C3

### DIFF
--- a/bloodPressureMonitorAM.raml
+++ b/bloodPressureMonitorAM.raml
@@ -12,7 +12,7 @@ documentation:
 schemas:
   - batch-retrieve: !include oic.collection.batch-retrieve-schema.json
   - links: !include oic.collection.linkslist-schema.json
-  - baseline: !include oic.collection-schema.json
+  - baseline: !include oic.r.bloodpressuremonitor-am.json
 
 traits:
   - interface-all:

--- a/bodyScaleAM.raml
+++ b/bodyScaleAM.raml
@@ -12,7 +12,7 @@ documentation:
 schemas:
   - batch-retrieve: !include oic.collection.batch-retrieve-schema.json
   - links: !include oic.collection.linkslist-schema.json
-  - baseline: !include oic.collection-schema.json
+  - baseline: !include oic.r.bodyscale-am.json
 
 traits:
   - interface-all:

--- a/glucoseMeterAM.raml
+++ b/glucoseMeterAM.raml
@@ -12,7 +12,7 @@ documentation:
 schemas:
   - batch-retrieve: !include oic.collection.batch-retrieve-schema.json
   - links: !include oic.collection.linkslist-schema.json
-  - baseline: !include oic.collection-schema.json
+  - baseline: !include oic.r.glucosemeter-am.json
 
 traits:
   - interface-all:

--- a/oic.r.bloodpressure.json
+++ b/oic.r.bloodpressure.json
@@ -25,7 +25,7 @@
           "readOnly": true,
           "description": "Mean Arterial Pressure (MAP)"
         },
-        "units": {
+        "unit": {
           "type": "string",
           "readOnly": true,
           "enum": ["mmHg", "kPa"],

--- a/oic.r.bloodpressuremonitor-am.json
+++ b/oic.r.bloodpressuremonitor-am.json
@@ -6,46 +6,45 @@
   "definitions": {
     "oic.r.bloodpressuremonitor-am": {
       "type": "object",
-      "allOf": [
-        {
-          "rt": {
-            "type": "array",
-            "minItems": 2,
-            "maxItems": 2,
-            "uniqueItems": true,
-            "items": {
-              "enum": ["oic.r.bloodpressuremonitor-am", "oic.wk.col.atomic"]
-            }
-          },
-          "rts": {
-            "type": "array",
-            "minItems": 1,
-            "maxItems": 4,
-            "uniqueItems": true,
-            "items": {
-              "enum": ["oic.r.bloodpressure", "oic.r.pulserate", "oic.r.userid", "oic.r.time.stamp"]
-            },
-            "description": "This contains all possible resource types for this atomic measurement."
-          },
-          "rts-m": {
-            "type": "array",
-            "minItems": 1,
-            "maxItems": 1,
-            "uniqueItems": true,
-            "items": {
-              "enum": ["oic.r.bloodpressure"]
-            },
-            "description": "This contains all mandatory resource types for this atomic measurement."
+      "properties": {
+        "rt": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "uniqueItems": true,
+          "items": {
+            "enum": ["oic.r.bloodpressuremonitor-am", "oic.wk.col.atomic"]
           }
+        },
+        "rts": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 4,
+          "uniqueItems": true,
+          "items": {
+            "enum": ["oic.r.bloodpressure", "oic.r.pulserate", "oic.r.userid", "oic.r.time.stamp"]
+          },
+          "description": "This contains all possible resource types for this atomic measurement."
+        },
+        "rts-m": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "enum": ["oic.r.bloodpressure"]
+          },
+          "description": "This contains all mandatory resource types for this atomic measurement."
         }
-      ]
+      }
     }
   },
   "type": "object",
   "allOf": [
     {"$ref": "oic.core.json#/definitions/oic.core"},
-    {"$ref": "#/definitions/oic.r.bloodpressuremonitor-am"},
-    {"$ref": "oic.collection-schema.json#/definitions/oic.collection"}
+    {"$ref": "oic.collection-schema.json#/definitions/oic.collection.properties"},
+    {"$ref": "oic.collection-schema.json#/definitions/oic.collection.links.arrayoflinks"},
+    {"$ref": "#/definitions/oic.r.bloodpressuremonitor-am"}
   ],
   "required": ["rts-m"]
 }

--- a/oic.r.body.location.temperature.json
+++ b/oic.r.body.location.temperature.json
@@ -20,7 +20,7 @@
   "allOf": [
     {"$ref": "oic.core.json#/definitions/oic.core"},
     {"$ref": "oic.baseResource.json#/definitions/oic.r.baseresource"},
-    {"$ref": "#/definitions/oic.r.body.location"},
+    {"$ref": "oic.r.body.location.json#/definitions/oic.r.body.location"},
     {"$ref": "#/definitions/oic.r.body.location.temperature"}
   ],
   "required": ["bloc"]

--- a/oic.r.bodyscale-am.json
+++ b/oic.r.bodyscale-am.json
@@ -6,46 +6,45 @@
   "definitions": {
     "oic.r.bodyscale-am": {
       "type": "object",
-      "allOf": [
-        {
-          "rt": {
-            "type": "array",
-            "minItems": 2,
-            "maxItems": 2,
-            "uniqueItems": true,
-            "items": {
-              "enum": ["oic.r.bodyscale-am", "oic.wk.col.atomic"]
-            }
-          },
-          "rts": {
-            "type": "array",
-            "minItems": 1,
-            "maxItems": 9,
-            "uniqueItems": true,
-            "items": {
-              "enum": ["oic.r.weight", "oic.r.bmi", "oic.r.height", "oic.r.body.fat", "oic.r.body.water", "oic.r.body.slm", "oic.r.body.ffm", "oic.r.time.stamp", "oic.r.userid"]
-            },
-            "description": "This contains all possible resource types for this atomic measurement."
-          },
-          "rts-m": {
-            "type": "array",
-            "minItems": 1,
-            "maxItems": 1,
-            "uniqueItems": true,
-            "items": {
-              "enum": ["oic.r.weight"]
-            },
-            "description": "This contains all mandatory resource types for this atomic measurement."
+      "properties": {
+        "rt": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "uniqueItems": true,
+          "items": {
+            "enum": ["oic.r.bodyscale-am", "oic.wk.col.atomic"]
           }
+        },
+        "rts": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 9,
+          "uniqueItems": true,
+          "items": {
+            "enum": ["oic.r.weight", "oic.r.bmi", "oic.r.height", "oic.r.body.fat", "oic.r.body.water", "oic.r.body.slm", "oic.r.body.ffm", "oic.r.time.stamp", "oic.r.userid"]
+          },
+          "description": "This contains all possible resource types for this atomic measurement."
+        },
+        "rts-m": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "enum": ["oic.r.weight"]
+          },
+          "description": "This contains all mandatory resource types for this atomic measurement."
         }
-      ]
+      }
     }
   },
   "type": "object",
   "allOf": [
     {"$ref": "oic.core.json#/definitions/oic.core"},
-    {"$ref": "#/definitions/oic.r.bodyscale-am"},
-    {"$ref": "oic.collection-schema.json#/definitions/oic.collection"}
+    {"$ref": "oic.collection-schema.json#/definitions/oic.collection.properties"},
+    {"$ref": "oic.collection-schema.json#/definitions/oic.collection.links.arrayoflinks"},
+    {"$ref": "#/definitions/oic.r.bodyscale-am"}
   ],
   "required": ["rts-m"]
 }

--- a/oic.r.bodythermometer-am.json
+++ b/oic.r.bodythermometer-am.json
@@ -6,46 +6,45 @@
   "definitions": {
     "oic.r.bodythermometer-am": {
       "type": "object",
-      "allOf": [
-        {
-          "rt": {
-            "type": "array",
-            "minItems": 2,
-            "maxItems": 2,
-            "uniqueItems": true,
-            "items": {
-              "enum": ["oic.r.bodythermometer-am", "oic.wk.col.atomic"]
-            }
-          },
-          "rts": {
-            "type": "array",
-            "minItems": 1,
-            "maxItems": 4,
-            "uniqueItems": true,
-            "items": {
-              "enum": ["oic.r.temperature", "oic.r.body.location.temperature", "oic.r.time.stamp", "oic.r.userid"]
-            },
-            "description": "This contains all possible resource types for this atomic measurement."
-          },
-          "rts-m": {
-            "type": "array",
-            "minItems": 1,
-            "maxItems": 1,
-            "uniqueItems": true,
-            "items": {
-              "enum": ["oic.r.temperature"]
-            },
-            "description": "This contains all mandatory resource types for this atomic measurement."
+      "properties": {
+        "rt": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "uniqueItems": true,
+          "items": {
+            "enum": ["oic.r.bodythermometer-am", "oic.wk.col.atomic"]
           }
+        },
+        "rts": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 4,
+          "uniqueItems": true,
+          "items": {
+            "enum": ["oic.r.temperature", "oic.r.body.location.temperature", "oic.r.time.stamp", "oic.r.userid"]
+          },
+          "description": "This contains all possible resource types for this atomic measurement."
+        },
+        "rts-m": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "enum": ["oic.r.temperature"]
+          },
+          "description": "This contains all mandatory resource types for this atomic measurement."
         }
-      ]
+      }
     }
   },
   "type": "object",
   "allOf": [
     {"$ref": "oic.core.json#/definitions/oic.core"},
-    {"$ref": "#/definitions/oic.r.bodythermometer-am"},
-    {"$ref": "oic.collection-schema.json#/definitions/oic.collection"}
+    {"$ref": "oic.collection-schema.json#/definitions/oic.collection.properties"},
+    {"$ref": "oic.collection-schema.json#/definitions/oic.collection.links.arrayoflinks"},
+    {"$ref": "#/definitions/oic.r.bodythermometer-am"}
   ],
   "required": ["rts-m"]
 }

--- a/oic.r.glucosemeter-am.json
+++ b/oic.r.glucosemeter-am.json
@@ -6,46 +6,45 @@
   "definitions": {
     "oic.r.glucosemeter-am": {
       "type": "object",
-      "allOf": [
-        {
-          "rt": {
-            "type": "array",
-            "minItems": 2,
-            "maxItems": 2,
-            "uniqueItems": true,
-            "items": {
-              "enum": ["oic.r.glucosemeter-am", "oic.wk.col.atomic"]
-            }
-          },
-          "rts": {
-            "type": "array",
-            "minItems": 1,
-            "maxItems": 11,
-            "uniqueItems": true,
-            "items": {
-              "enum": ["oic.r.glucose", "oic.r.glucose.carb", "oic.r.glucose.exercise", "oic.r.glucose.health", "oic.r.glucose.hba1c", "oic.r.glucose.meal", "oic.r.glucose.medication", "oic.r.glucose.samplelocation", "oic.r.glucose.tester", "oic.r.time.observed", "oic.r.userid"]
-            },
-            "description": "This contains all possible resource types for this atomic measurement."
-          },
-          "rts-m": {
-            "type": "array",
-            "minItems": 1,
-            "maxItems": 1,
-            "uniqueItems": true,
-            "items": {
-              "enum": ["oic.r.glucose"]
-            },
-            "description": "This contains all mandatory resource types for this atomic measurement."
+      "properties": {
+        "rt": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "uniqueItems": true,
+          "items": {
+            "enum": ["oic.r.glucosemeter-am", "oic.wk.col.atomic"]
           }
+        },
+        "rts": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 11,
+          "uniqueItems": true,
+          "items": {
+            "enum": ["oic.r.glucose", "oic.r.glucose.carb", "oic.r.glucose.exercise", "oic.r.glucose.health", "oic.r.glucose.hba1c", "oic.r.glucose.meal", "oic.r.glucose.medication", "oic.r.glucose.samplelocation", "oic.r.glucose.tester", "oic.r.time.observed", "oic.r.userid"]
+          },
+          "description": "This contains all possible resource types for this atomic measurement."
+        },
+        "rts-m": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "enum": ["oic.r.glucose"]
+          },
+          "description": "This contains all mandatory resource types for this atomic measurement."
         }
-      ]
+      }
     }
   },
   "type": "object",
   "allOf": [
     {"$ref": "oic.core.json#/definitions/oic.core"},
-    {"$ref": "#/definitions/oic.r.glucosemeter-am"},
-    {"$ref": "oic.collection-schema.json#/definitions/oic.collection"}
+    {"$ref": "oic.collection-schema.json#/definitions/oic.collection.properties"},
+    {"$ref": "oic.collection-schema.json#/definitions/oic.collection.links.arrayoflinks"},
+    {"$ref": "#/definitions/oic.r.glucosemeter-am"}
   ],
   "required": ["rts-m"]
 }

--- a/rbodyThermometerAM.raml
+++ b/rbodyThermometerAM.raml
@@ -12,7 +12,7 @@ documentation:
 schemas:
   - batch-retrieve: !include oic.collection.batch-retrieve-schema.json
   - links: !include oic.collection.linkslist-schema.json
-  - baseline: !include oic.collection-schema.json
+  - baseline: !include oic.r.bodythermometer-am.json
 
 traits:
   - interface-all:


### PR DESCRIPTION
Below are the corections of issues found while updating schemas for CTT:
- Changed the baseline interface of 4 new AM resources to be the schema for the specific resource, not the base collection schema, which does not have "rts" and "rts-m" properties
- In schemas for the AM resources changed "allOf" to "properties"
- In schemas for the AM resources replaced the reference to the non-existent oic.collection with references to oic.collection.properties and oic.collection.links.arrayoflinks
- Corrected an invalid reference in oic.r.body.location.temperature.json
- Corrected inconsistency property name in oic.r.bloodpressure  ("units" is schema, "unit" in RAML)