### PR TITLE
Corrections to ORFID

### DIFF
--- a/ORFID_station.raml
+++ b/ORFID_station.raml
@@ -36,7 +36,7 @@ traits:
             schema: ORFID
             example: |
               {
-                "rt":                   ["oic.r.orfid.tag"],
+                "rt":                   ["oic.r.orfid.station"],
                 "id":                   "unique_example_id",
                 "process":              17,
                 "event":                true,

--- a/oic.r.orfid_station.json
+++ b/oic.r.orfid_station.json
@@ -1,5 +1,5 @@
 {
-  "id": "http://openinterconnect.org/schemas/oic.r.oifid.station.json#",
+  "id": "http://openinterconnect.org/schemas/oic.r.orfid.station.json#",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "description" : "Copyright (c) 2016 Open Connectivity Foundation, Inc. All rights reserved.",
   "title": "ORFID",

--- a/oic.r.orfid_tag.json
+++ b/oic.r.orfid_tag.json
@@ -1,5 +1,5 @@
 {
-  "id": "http://openinterconnect.org/schemas/oic.r.oifid.tag.json#",
+  "id": "http://openinterconnect.org/schemas/oic.r.orfid.tag.json#",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "description" : "Copyright (c) 2018 Open Connectivity Foundation, Inc. All rights reserved.",
   "title": "ORFID",


### PR DESCRIPTION
While importing schema changes to CTT following issues were found:
- inconsitency between schema id and rt values in two schema files; assumed "oifid" should be changed to "orfid"
- wrong "rt" in example in ORFID_station.raml